### PR TITLE
Upvalue reassigned

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.6
 
 group = 'org.squiddev'
 version = '1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -16,3 +16,9 @@ dependencies {
 
 	testCompile group: 'junit', name: 'junit', version: '4.+'
 }
+
+test {
+	testLogging {
+		events "passed", "skipped", "failed", "standardOut", "standardError"
+	}
+}

--- a/src/main/java/org/luaj/vm2/lib/DebugLib.java
+++ b/src/main/java/org/luaj/vm2/lib/DebugLib.java
@@ -135,6 +135,7 @@ public class DebugLib extends VarArgFunction {
 		return t;
 	}
 
+	@Override
 	public Varargs invoke(Varargs args) {
 		switch (opcode) {
 			case INIT:
@@ -272,7 +273,7 @@ public class DebugLib extends VarArgFunction {
 	static class DebugState {
 		private final LuaThread thread;
 		private int debugCalls = 0;
-		private DebugInfo[] debugInfo = new DebugInfo[LuaThread.MAX_CALLSTACK + 1];
+		private final DebugInfo[] debugInfo = new DebugInfo[LuaThread.MAX_CALLSTACK + 1];
 		private LuaValue hookfunc;
 		private boolean hookcall, hookline, hookrtrn, inhook;
 		private int hookcount, hookcodes;

--- a/src/main/java/org/luaj/vm2/lib/StringLib.java
+++ b/src/main/java/org/luaj/vm2/lib/StringLib.java
@@ -63,6 +63,7 @@ public class StringLib extends OneArgFunction {
 	public StringLib() {
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg) {
 		LuaTable t = new LuaTable();
 		bind(t, StringLib1.class, new String[]{
@@ -81,6 +82,7 @@ public class StringLib extends OneArgFunction {
 	}
 
 	static final class StringLib1 extends OneArgFunction {
+		@Override
 		public LuaValue call(LuaValue arg) {
 			switch (opcode) {
 				case 0:
@@ -99,6 +101,7 @@ public class StringLib extends OneArgFunction {
 	}
 
 	static final class StringLibV extends VarArgFunction {
+		@Override
 		public Varargs invoke(Varargs args) {
 			switch (opcode) {
 				case 0:
@@ -562,6 +565,7 @@ public class StringLib extends OneArgFunction {
 			this.soffset = 0;
 		}
 
+		@Override
 		public Varargs invoke(Varargs args) {
 			for (; soffset < srclen; soffset++) {
 				ms.reset();

--- a/src/main/java/org/squiddev/luaj/luajc/BasicBlock.java
+++ b/src/main/java/org/squiddev/luaj/luajc/BasicBlock.java
@@ -74,11 +74,13 @@ public class BasicBlock {
 
 		// Mark beginning and end of blocks
 		BranchVisitor bv = new BranchVisitor(isBeginning) {
+			@Override
 			public void visitBranch(int pc0, int pc1) {
 				isEnd[pc0] = true;
 				isBeginning[pc1] = true;
 			}
 
+			@Override
 			public void visitReturn(int pc) {
 				isEnd[pc] = true;
 			}
@@ -102,6 +104,7 @@ public class BasicBlock {
 		final int[] nNext = new int[n];
 		final int[] nPrevious = new int[n];
 		visitBranches(p, new BranchVisitor(isBeginning) {
+			@Override
 			public void visitBranch(int pc0, int pc1) {
 				nNext[pc0]++;
 				nPrevious[pc1]++;
@@ -110,6 +113,7 @@ public class BasicBlock {
 
 		// Create the blocks and reference previous and next blocks
 		visitBranches(p, new BranchVisitor(isBeginning) {
+			@Override
 			public void visitBranch(int pc0, int pc1) {
 				if (blocks[pc0].next == null) blocks[pc0].next = new BasicBlock[nNext[pc0]];
 				if (blocks[pc1].prev == null) blocks[pc1].prev = new BasicBlock[nPrevious[pc1]];
@@ -128,7 +132,7 @@ public class BasicBlock {
 	 */
 	public static BasicBlock[] findLiveBlocks(BasicBlock[] blocks) {
 		// Add all reachable blocks
-		Queue<BasicBlock> next = new LinkedList<>();
+		Queue<BasicBlock> next = new LinkedList<BasicBlock>();
 		next.add(blocks[0]);
 
 		// For each item find the next blocks and add them to the queue
@@ -145,7 +149,7 @@ public class BasicBlock {
 		}
 
 		// Create list in natural order
-		List<BasicBlock> list = new ArrayList<>();
+		List<BasicBlock> list = new ArrayList<BasicBlock>();
 		for (int i = 0; i < blocks.length; i = blocks[i].pc1 + 1) {
 			if (blocks[i].isLive) {
 				list.add(blocks[i]);

--- a/src/main/java/org/squiddev/luaj/luajc/JavaBuilder.java
+++ b/src/main/java/org/squiddev/luaj/luajc/JavaBuilder.java
@@ -82,7 +82,7 @@ public class JavaBuilder {
 	}
 
 	// Manage super classes
-	protected static FunctionType[] SUPER_TYPES = {
+	protected static final FunctionType[] SUPER_TYPES = {
 		new FunctionType(ZeroArgFunction.class, "call"),
 		new FunctionType(OneArgFunction.class, "call", LuaValue.class),
 		new FunctionType(TwoArgFunction.class, "call", LuaValue.class, LuaValue.class),
@@ -195,13 +195,13 @@ public class JavaBuilder {
 	 */
 	protected int varargsLocal = -1;
 
-	Label start;
-	Label end;
+	final Label start;
+	final Label end;
 
 	// the superclass arg count, 0-3 args, 4=varargs
-	protected FunctionType superclass;
-	protected static int SUPERTYPE_VARARGS_ID = 4;
-	protected static FunctionType SUPERTYPE_VARARGS = SUPER_TYPES[SUPERTYPE_VARARGS_ID];
+	protected final FunctionType superclass;
+	protected static final int SUPERTYPE_VARARGS_ID = 4;
+	protected static final FunctionType SUPERTYPE_VARARGS = SUPER_TYPES[SUPERTYPE_VARARGS_ID];
 
 	/**
 	 * Go to destinations
@@ -438,8 +438,8 @@ public class JavaBuilder {
 		main.visitFieldInsn(GETSTATIC, "org/luaj/vm2/LuaValue", field, "Lorg/luaj/vm2/LuaBoolean;");
 	}
 
-	protected Map<Integer, Integer> plainSlotVars = new HashMap<>();
-	protected Map<Integer, Integer> upvalueSlotVars = new HashMap<>();
+	protected final Map<Integer, Integer> plainSlotVars = new HashMap<Integer, Integer>();
+	protected final Map<Integer, Integer> upvalueSlotVars = new HashMap<Integer, Integer>();
 
 	protected int findSlot(int luaSlot, Map<Integer, Integer> map) {
 		if (map.containsKey(luaSlot)) return map.get(luaSlot);
@@ -819,7 +819,7 @@ public class JavaBuilder {
 		main.visitFieldInsn(PUTFIELD, protoName, destName, type);
 	}
 
-	protected Map<LuaValue, String> constants = new HashMap<>();
+	protected final Map<LuaValue, String> constants = new HashMap<LuaValue, String>();
 
 	public void loadConstant(LuaValue value) {
 		switch (value.type()) {

--- a/src/main/java/org/squiddev/luaj/luajc/JavaLoader.java
+++ b/src/main/java/org/squiddev/luaj/luajc/JavaLoader.java
@@ -42,8 +42,8 @@ public class JavaLoader extends ClassLoader {
 	 */
 	private final LuaValue env;
 
-	private Map<String, byte[]> unloaded = new HashMap<>();
-	private Map<String, Prototype> prototypes = new HashMap<>();
+	private final Map<String, byte[]> unloaded = new HashMap<String, byte[]>();
+	private final Map<String, Prototype> prototypes = new HashMap<String, Prototype>();
 
 	public JavaLoader(LuaValue env) {
 		super(JavaLoader.class.getClassLoader());
@@ -84,6 +84,7 @@ public class JavaLoader extends ClassLoader {
 		}
 	}
 
+	@Override
 	public Class findClass(String className) throws ClassNotFoundException {
 		byte[] bytes = unloaded.get(className);
 		if (bytes != null) {

--- a/src/main/java/org/squiddev/luaj/luajc/JavaLoader.java
+++ b/src/main/java/org/squiddev/luaj/luajc/JavaLoader.java
@@ -35,7 +35,7 @@ public class JavaLoader extends ClassLoader {
 	 * Validate the sources on load
 	 * This helps debug but will slow down compilation massively
 	 */
-	public boolean verifySources = false;
+	public boolean verifySources = true;
 
 	/**
 	 * The environment to load files from

--- a/src/main/java/org/squiddev/luaj/luajc/LuaJC.java
+++ b/src/main/java/org/squiddev/luaj/luajc/LuaJC.java
@@ -53,6 +53,7 @@ public class LuaJC implements LoadState.LuaCompiler {
 		LoadState.compiler = getInstance();
 	}
 
+	@Override
 	public LuaFunction load(InputStream stream, String name, LuaValue env) throws IOException {
 		Prototype p = LuaC.compile(stream, name);
 		String className = toStandardJavaClassName(name);

--- a/src/main/java/org/squiddev/luaj/luajc/ProtoInfo.java
+++ b/src/main/java/org/squiddev/luaj/luajc/ProtoInfo.java
@@ -60,7 +60,7 @@ public class ProtoInfo {
 	/**
 	 * Storage for all phi variables in the prototype
 	 */
-	private final Set<VarInfo> phis = new HashSet<>();
+	private final Set<VarInfo> phis = new HashSet<VarInfo>();
 
 	public ProtoInfo(Prototype p, String name) {
 		this(p, name, null);

--- a/src/main/java/org/squiddev/luaj/luajc/ProtoInfo.java
+++ b/src/main/java/org/squiddev/luaj/luajc/ProtoInfo.java
@@ -93,9 +93,9 @@ public class ProtoInfo {
 	}
 
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 
-		// prototpye name
+		// prototype name
 		sb.append("proto '").append(name).append("'\n");
 
 		// upvalues from outer scopes
@@ -146,7 +146,7 @@ public class ProtoInfo {
 		return sb.toString();
 	}
 
-	private void appendOpenUps(StringBuffer sb, int pc) {
+	private void appendOpenUps(StringBuilder sb, int pc) {
 		for (int j = 0; j < prototype.maxstacksize; j++) {
 			VarInfo v = (pc < 0 ? params[j] : vars[j][pc]);
 			if (v != null && v.pc == pc && v.allocUpvalue) {
@@ -201,7 +201,6 @@ public class ProtoInfo {
 
 			// Process instructions for this basic block
 			for (int pc = b0.pc0; pc <= b0.pc1; pc++) {
-
 				// Propagate previous values except at block boundaries
 				if (pc > b0.pc0) {
 					propagateVars(v, pc - 1, pc);
@@ -213,32 +212,32 @@ public class ProtoInfo {
 
 				// Account for assignments, references and invalidation
 				switch (op) {
-					case Lua.OP_LOADK:/*	A Bx	R(A) := Kst(Bx)					*/
-					case Lua.OP_LOADBOOL:/*	A B C	R(A) := (Bool)B; if (C) pc++			*/
-					case Lua.OP_GETUPVAL: /*	A B	R(A) := UpValue[B]				*/
-					case Lua.OP_GETGLOBAL: /*	A Bx	R(A) := Gbl[Kst(Bx)]				*/
-					case Lua.OP_NEWTABLE: /*	A B C	R(A) := {} (size = B,C)				*/
+					case Lua.OP_LOADK:     // A Bx    R(A) := Kst(Bx)
+					case Lua.OP_LOADBOOL:  // A B  C  R(A) := (Bool)B; if (C) pc++
+					case Lua.OP_GETUPVAL:  // A B     R(A) := UpValue[B]
+					case Lua.OP_GETGLOBAL: // A Bx    R(A) := Gbl[Kst(Bx)]
+					case Lua.OP_NEWTABLE:  // A B  C  R(A) := {} (size = B,C)
 						a = Lua.GETARG_A(ins);
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_MOVE:/*	A B	R(A) := R(B)					*/
-					case Lua.OP_UNM: /*	A B	R(A) := -R(B)					*/
-					case Lua.OP_NOT: /*	A B	R(A) := not R(B)				*/
-					case Lua.OP_LEN: /*	A B	R(A) := length of R(B)				*/
-					case Lua.OP_TESTSET: /*	A B C	if (R(B) <=> C) then R(A) := R(B) else pc++	*/
+					case Lua.OP_MOVE:    // A B R(A) := R(B)
+					case Lua.OP_UNM:     // A B R(A) := -R(B)
+					case Lua.OP_NOT:     // A B R(A) := not R(B)
+					case Lua.OP_LEN:     // A B R(A) := length of R(B)
+					case Lua.OP_TESTSET: // A B C if (R(B) <=> C) then R(A) := R(B) else pc++
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						v[b][pc].isReferenced = true;
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_ADD: /*	A B C	R(A) := RK(B) + RK(C)				*/
-					case Lua.OP_SUB: /*	A B C	R(A) := RK(B) - RK(C)				*/
-					case Lua.OP_MUL: /*	A B C	R(A) := RK(B) * RK(C)				*/
-					case Lua.OP_DIV: /*	A B C	R(A) := RK(B) / RK(C)				*/
-					case Lua.OP_MOD: /*	A B C	R(A) := RK(B) % RK(C)				*/
-					case Lua.OP_POW: /*	A B C	R(A) := RK(B) ^ RK(C)				*/
+					case Lua.OP_ADD: // A B C R(A) := RK(B) + RK(C)
+					case Lua.OP_SUB: // A B C R(A) := RK(B) - RK(C)
+					case Lua.OP_MUL: // A B C R(A) := RK(B) * RK(C)
+					case Lua.OP_DIV: // A B C R(A) := RK(B) / RK(C)
+					case Lua.OP_MOD: // A B C R(A) := RK(B) % RK(C)
+					case Lua.OP_POW: // A B C R(A) := RK(B) ^ RK(C)
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -247,7 +246,7 @@ public class ProtoInfo {
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_SETTABLE: /*	A B C	R(A)[RK(B)]:= RK(C)				*/
+					case Lua.OP_SETTABLE: // A B C R(A)[RK(B)]:= RK(C)
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -256,7 +255,7 @@ public class ProtoInfo {
 						if (!Lua.ISK(c)) v[c][pc].isReferenced = true;
 						break;
 
-					case Lua.OP_CONCAT: /*	A B C	R(A) := R(B).. ... ..R(C)			*/
+					case Lua.OP_CONCAT: // A B C R(A) := R(B) .. ... .. R(C)
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -266,13 +265,13 @@ public class ProtoInfo {
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_FORPREP: /*	A sBx	R(A)-=R(A+2); pc+=sBx				*/
+					case Lua.OP_FORPREP: // A sBx R(A)-=R(A+2); pc+=sBx
 						a = Lua.GETARG_A(ins);
 						v[a + 2][pc].isReferenced = true;
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_GETTABLE: /*	A B C	R(A) := R(B)[RK(C)]				*/
+					case Lua.OP_GETTABLE: // A B C R(A) := R(B)[RK(C)]
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -281,7 +280,7 @@ public class ProtoInfo {
 						v[a][pc] = new VarInfo(a, pc);
 						break;
 
-					case Lua.OP_SELF: /*	A B C	R(A+1) := R(B); R(A) := R(B)[RK(C)]		*/
+					case Lua.OP_SELF: // A B C R(A+1) := R(B); R(A) := R(B)[RK(C)]
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -291,8 +290,7 @@ public class ProtoInfo {
 						v[a + 1][pc] = new VarInfo(a + 1, pc);
 						break;
 
-					case Lua.OP_FORLOOP: /*	A sBx	R(A)+=R(A+2);
-					if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }*/
+					case Lua.OP_FORLOOP: // A sBx R(A)+=R(A+2); if R(A) <?= R(A+1) then { pc+=sBx; R(A+3)=R(A) }
 						a = Lua.GETARG_A(ins);
 						v[a][pc].isReferenced = true;
 						v[a + 2][pc].isReferenced = true;
@@ -302,7 +300,7 @@ public class ProtoInfo {
 						v[a + 3][pc] = new VarInfo(a + 3, pc);
 						break;
 
-					case Lua.OP_LOADNIL: /*	A B	R(A) := ... := R(B) := nil			*/
+					case Lua.OP_LOADNIL: // A B R(A) ... R(B) := nil
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						for (; a <= b; a++) {
@@ -310,7 +308,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_VARARG: /*	A B	R(A), R(A+1), ..., R(A+B-1) = vararg		*/
+					case Lua.OP_VARARG: // A B R(A), R(A+1), ..., R(A+B-1) = vararg
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						for (int j = 1; j < b; j++, a++) {
@@ -323,7 +321,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_CALL: /*	A B C	R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1)) */
+					case Lua.OP_CALL: // A B C R(A), ... ,R(A+C-2) := R(A)(R(A+1), ... ,R(A+B-1))
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
@@ -340,7 +338,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_TAILCALL: /*	A B C	return R(A)(R(A+1), ... ,R(A+B-1))		*/
+					case Lua.OP_TAILCALL: // A B C return R(A)(R(A+1), ... ,R(A+B-1))
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						v[a][pc].isReferenced = true;
@@ -349,7 +347,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_RETURN: /*	A B	return R(A), ... ,R(A+B-2)	(see note)	*/
+					case Lua.OP_RETURN: // A B return R(A), ... ,R(A+B-2)
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						for (int i = 0; i <= b - 2; i++) {
@@ -357,8 +355,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_TFORLOOP: /*	A C	R(A+3), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2));
-					                    if R(A+3) ~= nil then R(A+2)=R(A+3) else pc++	*/
+					case Lua.OP_TFORLOOP: // A C R(A+3), ... ,R(A+2+C) := R(A)(R(A+1), R(A+2)); if R(A+3) ~= nil then R(A+2)=R(A+3) else pc++
 						a = Lua.GETARG_A(ins);
 						c = Lua.GETARG_C(ins);
 						v[a++][pc].isReferenced = true;
@@ -372,7 +369,7 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_CLOSURE: /*	A Bx	R(A) := closure(KPROTO[Bx], R(A), ... ,R(A+n))	*/
+					case Lua.OP_CLOSURE: // A Bx R(A) := closure(KPROTO[Bx], R(A), ... ,R(A+n))
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_Bx(ins);
 						nups = prototype.p[b].nups;
@@ -389,14 +386,14 @@ public class ProtoInfo {
 						}
 						pc += nups;
 						break;
-					case Lua.OP_CLOSE: /*	A 	close all variables in the stack up to (>=) R(A)*/
+					case Lua.OP_CLOSE: // A close all variables in the stack up to (>=) R(A)
 						a = Lua.GETARG_A(ins);
 						for (; a < m; a++) {
 							v[a][pc] = VarInfo.INVALID;
 						}
 						break;
 
-					case Lua.OP_SETLIST: /*	A B C	R(A)[(C-1)*FPF+i]:= R(A+i), 1 <= i <= B	*/
+					case Lua.OP_SETLIST: // A B C R(A)[(C-1)*FPF+i]:= R(A+i), 1 <= i <= B
 						a = Lua.GETARG_A(ins);
 						b = Lua.GETARG_B(ins);
 						v[a][pc].isReferenced = true;
@@ -405,23 +402,23 @@ public class ProtoInfo {
 						}
 						break;
 
-					case Lua.OP_SETGLOBAL: /*	A Bx	Gbl[Kst(Bx)]:= R(A)				*/
-					case Lua.OP_SETUPVAL: /*	A B	UpValue[B]:= R(A)				*/
-					case Lua.OP_TEST: /*	A C	if not (R(A) <=> C) then pc++			*/
+					case Lua.OP_SETGLOBAL: // A Bx Gbl[Kst(Bx)]:= R(A)
+					case Lua.OP_SETUPVAL:  // A B  UpValue[B]:= R(A)
+					case Lua.OP_TEST:      // A C  if not (R(A) <=> C) then pc++
 						a = Lua.GETARG_A(ins);
 						v[a][pc].isReferenced = true;
 						break;
 
-					case Lua.OP_EQ: /*	A B C	if ((RK(B) == RK(C)) ~= A) then pc++		*/
-					case Lua.OP_LT: /*	A B C	if ((RK(B) <  RK(C)) ~= A) then pc++  		*/
-					case Lua.OP_LE: /*	A B C	if ((RK(B) <= RK(C)) ~= A) then pc++  		*/
+					case Lua.OP_EQ: // A B C if ((RK(B) == RK(C)) ~= A) then pc++
+					case Lua.OP_LT: // A B C if ((RK(B) <  RK(C)) ~= A) then pc++
+					case Lua.OP_LE: // A B C if ((RK(B) <= RK(C)) ~= A) then pc++
 						b = Lua.GETARG_B(ins);
 						c = Lua.GETARG_C(ins);
 						if (!Lua.ISK(b)) v[b][pc].isReferenced = true;
 						if (!Lua.ISK(c)) v[c][pc].isReferenced = true;
 						break;
 
-					case Lua.OP_JMP: /*	sBx	pc+=sBx					*/
+					case Lua.OP_JMP: // sBx pc+=sBx
 						break;
 
 					default:
@@ -491,12 +488,15 @@ public class ProtoInfo {
 				Prototype childPrototype = prototype.p[bx];
 				String childName = name + "$" + bx;
 
-				UpvalueInfo[] childUpvalues = childPrototype.nups > 0 ? new UpvalueInfo[childPrototype.nups] : null;
+				UpvalueInfo[] childUpvalues = null;
 
-				for (int j = 0; j < childPrototype.nups; ++j) {
-					int i = code[++pc];
-					int b = Lua.GETARG_B(i);
-					childUpvalues[j] = (i & 4) != 0 ? upvalues[b] : findOpenUp(pc, b);
+				if (childPrototype.nups > 0) {
+					childUpvalues = new UpvalueInfo[childPrototype.nups];
+					for (int j = 0; j < childPrototype.nups; ++j) {
+						int i = code[++pc];
+						int b = Lua.GETARG_B(i);
+						childUpvalues[j] = (i & 4) != 0 ? upvalues[b] : findOpenUp(pc, b);
+					}
 				}
 
 				subprotos[bx] = new ProtoInfo(childPrototype, childName, childUpvalues);

--- a/src/main/java/org/squiddev/luaj/luajc/VarInfo.java
+++ b/src/main/java/org/squiddev/luaj/luajc/VarInfo.java
@@ -25,20 +25,6 @@ public class VarInfo {
 	}
 
 	/**
-	 * Create a {@link VarInfo} for a nil value
-	 *
-	 * @param slot The slot nil is stored in.
-	 * @return The resulting nil variable. The PC is set to -1
-	 */
-	public static VarInfo NIL(final int slot) {
-		return new VarInfo(slot, -1) {
-			public String toString() {
-				return "nil";
-			}
-		};
-	}
-
-	/**
 	 * Create a new {@link VarInfo.PhiVarInfo}
 	 *
 	 * @param pi   The prototype this variable is part of
@@ -57,7 +43,7 @@ public class VarInfo {
 
 	/**
 	 * The PC this variable is written at
-	 * -1 for a block inpts
+	 * -1 for a block inputs
 	 */
 	public final int pc; // where assigned, or -1 if for block inputs
 

--- a/src/main/java/org/squiddev/luaj/luajc/VarInfo.java
+++ b/src/main/java/org/squiddev/luaj/luajc/VarInfo.java
@@ -133,6 +133,7 @@ public class VarInfo {
 			this.pi = pi;
 		}
 
+		@Override
 		public boolean isPhiVar() {
 			return true;
 		}
@@ -161,8 +162,8 @@ public class VarInfo {
 		 */
 		@Override
 		public VarInfo resolvePhiVariableValues() {
-			Set<BasicBlock> visitedBlocks = new HashSet<>();
-			Set<VarInfo> vars = new HashSet<>();
+			Set<BasicBlock> visitedBlocks = new HashSet<BasicBlock>();
+			Set<VarInfo> vars = new HashSet<VarInfo>();
 			collectUniqueValues(visitedBlocks, vars);
 
 			if (vars.contains(INVALID)) return INVALID;

--- a/src/main/java/org/squiddev/luaj/luajc/function/LuaCompiledFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/LuaCompiledFunction.java
@@ -54,27 +54,6 @@ public abstract class LuaCompiledFunction extends LuaFunction implements IGetSou
 	protected String source;
 	protected int startLine;
 
-	/**
-	 * Java code generation utility to allocate storage for upvalue, leave it empty
-	 */
-	public static LuaValue[] newupe() {
-		return new LuaValue[1];
-	}
-
-	/**
-	 * Java code generation utility to allocate storage for upvalue, initialize with nil
-	 */
-	public static LuaValue[] newupn() {
-		return new LuaValue[]{NIL};
-	}
-
-	/**
-	 * Java code generation utility to allocate storage for upvalue, initialize with value
-	 */
-	public static LuaValue[] newupl(LuaValue v) {
-		return new LuaValue[]{v};
-	}
-
 	@Override
 	public String getSource() {
 		return source;

--- a/src/main/java/org/squiddev/luaj/luajc/function/LuaCompiledSource.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/LuaCompiledSource.java
@@ -32,10 +32,12 @@ public class LuaCompiledSource extends LuaFunction implements IGetSource {
 		return parent.getPrototype();
 	}
 
+	@Override
 	public LuaValue getfenv() {
 		return parent.getfenv();
 	}
 
+	@Override
 	public void setfenv(LuaValue env) {
 		parent.setfenv(env);
 	}

--- a/src/main/java/org/squiddev/luaj/luajc/function/OneArgFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/OneArgFunction.java
@@ -51,21 +51,25 @@ import org.luaj.vm2.Varargs;
  * @see VarArgFunction
  */
 abstract public class OneArgFunction extends LuaCompiledFunction {
-
+	@Override
 	abstract public LuaValue call(LuaValue arg);
 
+	@Override
 	public final LuaValue call() {
 		return call(NIL);
 	}
 
+	@Override
 	public final LuaValue call(LuaValue arg1, LuaValue arg2) {
 		return call(arg1);
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
 		return call(arg1);
 	}
 
+	@Override
 	public Varargs invoke(Varargs varargs) {
 		return call(varargs.arg1());
 	}

--- a/src/main/java/org/squiddev/luaj/luajc/function/Reference.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/Reference.java
@@ -1,0 +1,38 @@
+package org.squiddev.luaj.luajc.function;
+
+import org.luaj.vm2.LuaValue;
+
+/**
+ * Reference to a LuaValue
+ */
+public class Reference {
+	public LuaValue value;
+
+	public Reference() {
+	}
+
+	public Reference(LuaValue value) {
+		this.value = value;
+	}
+
+	/**
+	 * Java code generation utility to allocate storage for upvalue, leave it empty
+	 */
+	public static Reference newupe() {
+		return new Reference();
+	}
+
+	/**
+	 * Java code generation utility to allocate storage for upvalue, initialize with nil
+	 */
+	public static Reference newupn() {
+		return new Reference(LuaValue.NIL);
+	}
+
+	/**
+	 * Java code generation utility to allocate storage for upvalue, initialize with value
+	 */
+	public static Reference newupl(LuaValue v) {
+		return new Reference(v);
+	}
+}

--- a/src/main/java/org/squiddev/luaj/luajc/function/ThreeArgFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/ThreeArgFunction.java
@@ -51,23 +51,26 @@ import org.luaj.vm2.Varargs;
  * @see VarArgFunction
  */
 abstract public class ThreeArgFunction extends LuaCompiledFunction {
-
+	@Override
 	abstract public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3);
 
+	@Override
 	public final LuaValue call() {
 		return call(NIL, NIL, NIL);
 	}
 
+	@Override
 	public final LuaValue call(LuaValue arg) {
 		return call(arg, NIL, NIL);
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2) {
 		return call(arg1, arg2, NIL);
 	}
 
+	@Override
 	public Varargs invoke(Varargs varargs) {
 		return call(varargs.arg1(), varargs.arg(2), varargs.arg(3));
 	}
-
 }

--- a/src/main/java/org/squiddev/luaj/luajc/function/TwoArgFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/TwoArgFunction.java
@@ -51,23 +51,26 @@ import org.luaj.vm2.Varargs;
  * @see VarArgFunction
  */
 abstract public class TwoArgFunction extends LuaCompiledFunction {
-
+	@Override
 	abstract public LuaValue call(LuaValue arg1, LuaValue arg2);
 
+	@Override
 	public final LuaValue call() {
 		return call(NIL, NIL);
 	}
 
+	@Override
 	public final LuaValue call(LuaValue arg) {
 		return call(arg, NIL);
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
 		return call(arg1, arg2);
 	}
 
+	@Override
 	public Varargs invoke(Varargs varargs) {
 		return call(varargs.arg1(), varargs.arg(2));
 	}
-
 }

--- a/src/main/java/org/squiddev/luaj/luajc/function/VarArgFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/VarArgFunction.java
@@ -57,21 +57,26 @@ abstract public class VarArgFunction extends LuaCompiledFunction {
 		this.env = env;
 	}
 
+	@Override
 	public LuaValue call() {
 		return invoke(NONE).arg1();
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg) {
 		return invoke(arg).arg1();
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2) {
 		return invoke(varargsOf(arg1, arg2)).arg1();
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
 		return invoke(varargsOf(arg1, arg2, arg3)).arg1();
 	}
 
+	@Override
 	public abstract Varargs invoke(Varargs args);
 }

--- a/src/main/java/org/squiddev/luaj/luajc/function/ZeroArgFunction.java
+++ b/src/main/java/org/squiddev/luaj/luajc/function/ZeroArgFunction.java
@@ -49,21 +49,25 @@ import org.luaj.vm2.Varargs;
  * @see VarArgFunction
  */
 abstract public class ZeroArgFunction extends LuaCompiledFunction {
-
+	@Override
 	abstract public LuaValue call();
 
+	@Override
 	public LuaValue call(LuaValue arg) {
 		return call();
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2) {
 		return call();
 	}
 
+	@Override
 	public LuaValue call(LuaValue arg1, LuaValue arg2, LuaValue arg3) {
 		return call();
 	}
 
+	@Override
 	public Varargs invoke(Varargs varargs) {
 		return call();
 	}

--- a/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
+++ b/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
@@ -39,7 +39,7 @@ public class CompilerTest {
 			{"Recursive"},
 			{"Error"},
 			{"BranchUpvalue"},
-			{"BranchUpvalue2"},
+			// {"BranchUpvalue2"}, For the time being
 			{"RecursiveTrace"},
 			{"TailCall"},
 			{"StringDump"},

--- a/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
+++ b/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
@@ -39,6 +39,7 @@ public class CompilerTest {
 			{"Recursive"},
 			{"Error"},
 			{"BranchUpvalue"},
+			{"BranchUpvalue2"},
 			{"RecursiveTrace"},
 			{"TailCall"},
 			{"StringDump"},

--- a/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
+++ b/src/test/java/org/squiddev/luaj/luajc/CompilerTest.java
@@ -92,7 +92,7 @@ public class CompilerTest {
 		});
 	}
 
-	protected String name;
+	protected final String name;
 	protected LuaValue globals;
 
 	public CompilerTest(String name) {

--- a/src/test/java/org/squiddev/luaj/luajc/PerformanceRunner.java
+++ b/src/test/java/org/squiddev/luaj/luajc/PerformanceRunner.java
@@ -27,7 +27,7 @@ public class PerformanceRunner {
 
 		// Ugly parse arguments
 		if (args.length > 0) {
-			Queue<String> arg = new ArrayDeque<>(Arrays.asList(args));
+			Queue<String> arg = new ArrayDeque<String>(Arrays.asList(args));
 			String next;
 			while ((next = arg.poll()) != null) {
 				if (next.startsWith("--")) {
@@ -35,44 +35,31 @@ public class PerformanceRunner {
 				} else if (next.startsWith("-")) {
 					next = next.substring(1);
 				}
-				switch (next) {
-					case "t":
-					case "times":
-						String number = arg.poll();
-						if (number == null) throw new IllegalArgumentException();
-						times = Integer.parseInt(number);
-						break;
-					case "j":
-					case "luajc":
-						luaJC = false;
-						break;
-					case "l":
-					case "luac":
-						luaC = false;
-						break;
-					case "v":
-					case "verbose":
-						QUIET = false;
-						break;
-					case "q":
-					case "quiet":
-						QUIET = true;
-						break;
-					case "p":
-					case "prompt":
-						System.in.read();
-						break;
-					default:
-						System.out.print(
-							"Args\n" +
-								"  -t|--times <number> Run this n times\n" +
-								"  -j|--luajc          Don't run LuaJC\n" +
-								"  -l|--luac           Don't run LuaC\n" +
-								"  -v|--verbose        Verbose output\n" +
-								"  -q|--quiet          Quiet output\n" +
-								"  -p|--prompt         Prompt to begin\n"
-						);
-						return;
+				if (next.equals("t") || next.equals("times")) {
+					String number = arg.poll();
+					if (number == null) throw new IllegalArgumentException();
+					times = Integer.parseInt(number);
+				} else if (next.equals("j") || next.equals("luajc")) {
+					luaJC = false;
+				} else if (next.equals("l") || next.equals("luac")) {
+					luaC = false;
+				} else if (next.equals("v") || next.equals("verbose")) {
+					QUIET = false;
+				} else if (next.equals("q") || next.equals("quiet")) {
+					QUIET = true;
+				} else if (next.equals("p") || next.equals("prompt")) {
+					System.in.read();
+				} else {
+					System.out.print(
+						"Args\n" +
+							"  -t|--times <number> Run this n times\n" +
+							"  -j|--luajc          Don't run LuaJC\n" +
+							"  -l|--luac           Don't run LuaC\n" +
+							"  -v|--verbose        Verbose output\n" +
+							"  -q|--quiet          Quiet output\n" +
+							"  -p|--prompt         Prompt to begin\n"
+					);
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
From SquidDev-CC/Studio#14

We are getting generation errors with a very edge case piece of code:

``` lua
local upvalue

local function closure()
    return upvalue
end

while true do
    if "const" ~= "const" then
        upvalue = "const"
    else
        for loop_num = "const", "const" do
            for loop_iter in func() do
                func(loop_num + loop_iter)
            end
        end
    end
end
```

The trouble is at the end of the for loop (line 12: `for loop_iter in func()`). As the upvalue is reassigned within a branch statement there seems to be an issue that the upvalue is created and stored as an upvalue straight away, and so the upvalue slot is empty.

It seems it wants to convert an upvalue despite one has already been converted.
